### PR TITLE
Fix dead link to paper in benchmarking documentation

### DIFF
--- a/llvm/docs/Benchmarking.rst
+++ b/llvm/docs/Benchmarking.rst
@@ -11,8 +11,8 @@ noise as much as possible. How to do that is very OS dependent.
 
 Note that low noise is required, but not sufficient. It does not
 exclude measurement bias. See
-https://www.cis.upenn.edu/~cis501/papers/producing-wrong-data.pdf for
-example.
+https://users.cs.northwestern.edu/~robby/courses/322-2013-spring/mytkowicz-wrong-data.pdf 
+for example.
 
 General
 ================================


### PR DESCRIPTION
I noticed a dead paper link in this documentation. I am 90% sure this is the right paper since I have seen this paper cited in other computer architecture classes similar to the UPenn one that the link was originally from.